### PR TITLE
Clean up build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,70 +10,41 @@ defaultTasks 'jar'
 
 assert gradle.gradleVersion == '7.2'
 
+tasks.withType(JavaCompile) {
+    options.compilerArgs += ['-Xlint:unchecked']
+}
+
 final File javaHome = new File(System.getProperty('java.home'))
 final String JNI_INCLUDE_DIR = new File(javaHome, 'include').isDirectory()
         ? new File(javaHome, 'include').getPath() // JDK
         : new File(javaHome, '../include').getPath() // for JRE inside JDK
 
-model {
-    platforms {
-        x86_64 {
-            architecture 'x86_64'
-        }
-        linux_aarch64 {
-            operatingSystem "linux"
-            architecture "arm64"
-        }
+def isMacOs = System.properties['os.name'].equals('Mac OS X')
+tasks.register('compileC', Exec) {
+    executable 'gcc'
+    args "-std=c99", "-O2", "-Wall", "-Wextra", "-Werror",
+        "-Wno-unused-parameter", "-D_XOPEN_SOURCE=600", "-fPIC",
+        '-I', '/usr/local/include',
+        '-I', JNI_INCLUDE_DIR
+    if (isMacOs) {
+        args '-I', JNI_INCLUDE_DIR + '/darwin',
+            '-dynamiclib'
     }
-
-    toolChains {
-        clang(Clang)
-        gcc(Gcc) {
-            target("linux_aarch64")
-            target("linux_arm-v7")
-        }
+    else {
+        args '-I', JNI_INCLUDE_DIR + '/linux'
+        args '-shared'
     }
-
-    components {
-        jhwbus(NativeLibrarySpec){
-            binaries.all {
-                if (System.properties['os.name'].equals('Mac OS X')){
-                    cCompiler.args "-std=c99", "-O2", "-Wall", "-Wextra", "-Werror",
-                            "-Wno-unused-parameter", "-D_XOPEN_SOURCE=600", "-fPIC",
-                            '-I', '/usr/local/include',
-                            '-I', JNI_INCLUDE_DIR,
-                            '-I', JNI_INCLUDE_DIR + '/darwin'
-
-                } else {
-                    cCompiler.args "-std=c99", "-O2", "-Wall", "-Wextra", "-Werror",
-                            "-Wno-unused-parameter", "-D_XOPEN_SOURCE=600", "-fPIC",
-                            '-I', '/usr/local/include',
-                            '-I', JNI_INCLUDE_DIR,
-                            '-I', JNI_INCLUDE_DIR + '/linux'
-                    linker.args "-li2c"
-                }
-
-            }
-            sources {
-                c {
-                    source {
-                        srcDir "src/main"
-                        include "**/*.c"
-                    }
-                }
-            }
-        }
-    }
+    inputs.files fileTree('src/main/c') { include '**/*.c' }
+    if (isMacOs) outputs.file project.layout.buildDirectory.file('libjhwbus.dylib')
+    else outputs.file project.layout.buildDirectory.file('libjhwbus.so')
+    args '-o', outputs.files.singleFile
+    args inputs.files
 }
-
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ['-Xlint:unchecked']
+tasks.register('createJhwbusResourceDir', Sync) {
+    from tasks.named('compileC')
+    into project.layout.buildDirectory.dir('jhwbus')
 }
-
-sourceSets.main.resources.srcDirs += ["$buildDir/libs/jhwbus/shared"]
-
-// Hack to add the dependency such that it works with source dependency/composite builds
-tasks.matching{ it.name.contains('jhwbusSharedLibrary') }.whenTaskAdded {tasks.processResources.dependsOn it }
+sourceSets.main.resources.srcDirs tasks.named('createJhwbusResourceDir')
 
 repositories {
     mavenCentral()
@@ -91,5 +62,4 @@ test {
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"
     }
-    systemProperty "java.library.path", "${projectDir}/build/libs/jhwbus/shared"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,8 @@ version '1.1.1'
 
 defaultTasks 'jar'
 
+assert gradle.gradleVersion == '7.2'
+
 final File javaHome = new File(System.getProperty('java.home'))
 final String JNI_INCLUDE_DIR = new File(javaHome, 'include').isDirectory()
         ? new File(javaHome, 'include').getPath() // JDK

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -55,7 +55,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/HEAD/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.
@@ -80,13 +80,11 @@ do
     esac
 done
 
-APP_HOME=$( cd "${APP_HOME:-./}" && pwd -P ) || exit
-
-APP_NAME="Gradle"
+# This is normally unused
+# shellcheck disable=SC2034
 APP_BASE_NAME=${0##*/}
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+# Discard cd standard output in case $CDPATH is set (https://github.com/gradle/gradle/issues/25036)
+APP_HOME=$( cd "${APP_HOME:-./}" > /dev/null && pwd -P ) || exit
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD=maximum
@@ -133,22 +131,29 @@ location of your Java installation."
     fi
 else
     JAVACMD=java
-    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+    if ! command -v java >/dev/null 2>&1
+    then
+        die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
+    fi
 fi
 
 # Increase the maximum file descriptors if we can.
 if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
+        # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
     case $MAX_FD in  #(
       '' | soft) :;; #(
       *)
+        # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -193,17 +198,27 @@ if "$cygwin" || "$msys" ; then
     done
 fi
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
+
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \
         -classpath "$CLASSPATH" \
         org.gradle.wrapper.GradleWrapperMain \
         "$@"
+
+# Stop when "xargs" is not available.
+if ! command -v xargs >/dev/null 2>&1
+then
+    die "xargs is not available"
+fi
 
 # Use "xargs" to parse quoted args.
 #

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@
 @rem limitations under the License.
 @rem
 
-@if "%DEBUG%" == "" @echo off
+@if "%DEBUG%"=="" @echo off
 @rem ##########################################################################
 @rem
 @rem  Gradle startup script for Windows
@@ -25,7 +25,8 @@
 if "%OS%"=="Windows_NT" setlocal
 
 set DIRNAME=%~dp0
-if "%DIRNAME%" == "" set DIRNAME=.
+if "%DIRNAME%"=="" set DIRNAME=.
+@rem This is normally unused
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
@@ -40,7 +41,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if %ERRORLEVEL% equ 0 goto execute
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -75,13 +76,15 @@ set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
 :end
 @rem End local scope for the variables with windows NT shell
-if "%ERRORLEVEL%"=="0" goto mainEnd
+if %ERRORLEVEL% equ 0 goto mainEnd
 
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-exit /b 1
+set EXIT_CODE=%ERRORLEVEL%
+if %EXIT_CODE% equ 0 set EXIT_CODE=1
+if not ""=="%GRADLE_EXIT_CONSOLE%" exit %EXIT_CODE%
+exit /b %EXIT_CODE%
 
 :mainEnd
 if "%OS%"=="Windows_NT" endlocal


### PR DESCRIPTION
Fixes https://github.com/org-arl/jhwbus/issues/8, i.e. updates the build script so it works on Gradle v7.2. 

In addition:

- Updates `gradlew` to v7.2 (the version currently used by `unet`).
- Adds a check to `build.gradle` which makes the build fail if the Gradle version is not 7.2. 

The rationale for the version check is to make sure that changes to the Gradle version of `unet` can no longer silently break `jhwbus`, as it has done in https://github.com/org-arl/jhwbus/issues/8. I suspect this check will lead to some noise in the short term, but I would argue that the extra protection against accidentally shipping a broken build should make this worthwhile. In fact, we might even want to add the same check also to `unet` and possibly other packages to make sure `gradle build` and `./gradlew build` always produce the same output. 

The `jhwbus` JAR files are identical before and after this change, and I've checked that `./gradlew modem` works on the build machine. 