### PR TITLE
Fix missing link to libi2c on linux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ tasks.register('compileC', Exec) {
     else outputs.file project.layout.buildDirectory.file('libjhwbus.so')
     args '-o', outputs.files.singleFile
     args inputs.files
+    if(!isMacOs) args '-li2c'
 }
 tasks.register('createJhwbusResourceDir', Sync) {
     from tasks.named('compileC')


### PR DESCRIPTION
When we moved from the old gradle based compilation to the new `Exec`/`gcc` based one, we missed out linking to libi2c when we build the shared `libjhwbus.so` library.

https://github.com/org-arl/jhwbus/commit/ef1060ae4eca0fad89c223934d1b6ef64ac16d03#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L53

This PR adds that back.