### PR TITLE
Making jhwbus only build for Linux/ARM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ sftp-config.json
 
 #gradle
 .gradle
+gradle.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:18.04
+
+LABEL org.opencontainers.image.source="https://github.com/org-arl/jhwbus"
+LABEL org.opencontainers.image.authors="jhwbus"
+
+ARG JDK_VERSION=8u422
+ARG JDK_VERSION_RELEASE=b05
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV USER=ubuntu
+
+RUN mkdir -p /home/jhwbus
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+  ca-certificates \
+  curl \
+  gpg \
+  gcc \
+  locales \
+  libi2c-dev
+
+# Install AdoptOpenJDK 8
+RUN curl -L https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /etc/apt/trusted.gpg.d/adoptium.gpg
+RUN sh -c "echo \"deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main\" | tee 'etc/apt/sources.list.d/adoptium.list'"
+RUN apt update && apt -y install temurin-8-jdk
+
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+WORKDIR /home/jhwbus

--- a/README.md
+++ b/README.md
@@ -1,51 +1,56 @@
 # jhwbus
-Java hardware bus access
+Java hardware bus access for Linux
 
-A simple, thin JNI based Java library to enable accessing hardware buses (for eg. I2C) from Java on Linux. Bundles the native library into the jar and dynamically loads it at runtime.
+A simple, thin JNI based Java library to access simple hardware buses (for e.g. I2C) from Java on Linux. The library jar brings along the native library (`libjhwbus.so`) and dynamically loads it at runtime. Since Linux only supports simple hardware buses directly on ARM, this library is **only supported for Linux on ARM machines**.
 
-Currently supports the following hardware:
+Currently, supports the following hardware buses:
 
-- I2C/SMBUS
-
-Currently supports the following operating systems:
-
-- Linux
-- macOS (dummy support for testing only)
+- I2C/SMBUS - [Linux I2C](https://www.kernel.org/doc/html/latest/i2c/index.html)
 
 ## Building
 
+The JNI library is written in C and uses the `i2c-dev` interface to access the I2C bus. The library is built using the `gcc` compiler.
+
+The default `./gradlew` build task will build and package the library into a jar file.
+
+On a native Linux OS (running on an ARM machine), the build task can be run directly. On non-Linux OS, the build task can be run in a containerized environment using Docker.
+
+The Dockerfile used for the containerized build is [available here](Dockerfile)
+
 ### Requirements
 
-- Java
-- gcc
-- gradle
+#### On Linux
 
-Ensure that the environment variable `JAVA_HOME` is defined and points the Java installation.
+- Java JDK8
+- gcc
+- [libi2c-dev](https://www.kernel.org/doc/html/latest/i2c/dev-interface.html) - `sudo apt-get install libi2c-dev`
+
+> Ensure that the environment variable `JAVA_HOME` is defined and points the Java installation.
+
+#### On non-Linux (macos)
+
+- Container runtime like [Docker Desktop](https://www.docker.com/products/docker-desktop) or [Colima](https://github.com/abiosoft/colima)
+
+Since we need to build the native library for ARM architecture, the container runtime has to either run on an ARM machine or support ARM emulation.
 
 ### Commands
 
-`gradle` : Generates a jar with the native library included in `build/libs`
+`./gradlew` : Generates a jar with the native library included in `build/libs`
 
 ### Using
 
-Since the library is very platform (OS and architecture) specific, it is recommended that you add it as [gradle source dependency](https://blog.gradle.org/introducing-source-dependencies) instead of a normal gradle dependency, so that it gets compiled on your platform.
-
-In `settings.gradle` : 
+The library is published to GitHub Packages and can be included in the project using the following `build.gradle` configuration:
 
 ```groovy
-sourceControl {
-  gitRepository("https://github.com/org-arl/jhwbus.git") {
-    producesModule("org.arl.jhwbus:jhwbus")
-  }
-}
-```
-
-In `build.gradle` : 
-```groovy
- implementation('org.arl.jhwbus:jhwbus:1.1.1') {
-    version {
-        branch = 'master'
+repositories {
+    maven {
+        name = "GitHubPackages-jhwbus"
+        url = uri("https://maven.pkg.github.com/jhwbus/jhwbus")
     }
+}
+
+dependencies {
+    implementation 'io.github.jhwbus:jhwbus:1.2.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,51 +1,14 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 plugins {
-    id 'c'
     id 'groovy'
+    id 'maven-publish'
 }
 
 group 'org.arl.jhwbus'
-version '1.1.1'
-
-defaultTasks 'jar'
+version '1.2.0'
 
 assert gradle.gradleVersion.startsWith('7.')
-
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ['-Xlint:unchecked']
-}
-
-final File javaHome = new File(System.getProperty('java.home'))
-final String JNI_INCLUDE_DIR = new File(javaHome, 'include').isDirectory()
-        ? new File(javaHome, 'include').getPath() // JDK
-        : new File(javaHome, '../include').getPath() // for JRE inside JDK
-
-def isMacOs = System.properties['os.name'].equals('Mac OS X')
-tasks.register('compileC', Exec) {
-    executable 'gcc'
-    args "-std=c99", "-O2", "-Wall", "-Wextra", "-Werror",
-        "-Wno-unused-parameter", "-D_XOPEN_SOURCE=600", "-fPIC",
-        '-I', '/usr/local/include',
-        '-I', JNI_INCLUDE_DIR
-    if (isMacOs) {
-        args '-I', JNI_INCLUDE_DIR + '/darwin',
-            '-dynamiclib'
-    }
-    else {
-        args '-I', JNI_INCLUDE_DIR + '/linux'
-        args '-shared'
-    }
-    inputs.files fileTree('src/main/c') { include '**/*.c' }
-    if (isMacOs) outputs.file project.layout.buildDirectory.file('libjhwbus.dylib')
-    else outputs.file project.layout.buildDirectory.file('libjhwbus.so')
-    args '-o', outputs.files.singleFile
-    args inputs.files
-    if(!isMacOs) args '-li2c'
-}
-tasks.register('createJhwbusResourceDir', Sync) {
-    from tasks.named('compileC')
-    into project.layout.buildDirectory.dir('jhwbus')
-}
-sourceSets.main.resources.srcDirs tasks.named('createJhwbusResourceDir')
 
 repositories {
     mavenCentral()
@@ -56,6 +19,156 @@ dependencies {
     testImplementation 'org.codehaus.groovy:groovy-all:3.0.8'
 }
 
+String OS_NAME = "??"
+if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    OS_NAME = "windows"
+} else if (Os.isFamily(Os.FAMILY_MAC)) {
+    OS_NAME = "macos"
+} else if (Os.isFamily(Os.FAMILY_UNIX)) {
+    OS_NAME = "linux"
+}
+
+if (OS_NAME == "??") {
+    throw new GradleException("Unsupported OS: ${System.getProperty('os.name')}")
+}
+
+if (OS_NAME == 'linux'){
+    println "Building directly on Linux..."
+    defaultTasks 'jar'
+} else{
+    println "Building in a container..."
+    defaultTasks 'containerJar'
+}
+
+def JAVA_HOME = new File(System.getProperty('java.home'))
+def JNI_INCLUDE_DIR = new File(JAVA_HOME, 'include').isDirectory()
+    ? new File(JAVA_HOME, 'include').getPath() // JDK
+    : new File(JAVA_HOME, '../include').getPath() // for JRE inside JDK
+
+
+publishing {
+    publications {
+        // publish to maven only the jar file with `arch` classifier
+        maven(MavenPublication) {
+            artifact file("$buildDir/libs/jhwbus-${version}.jar")
+        }
+    }
+    repositories {
+        maven {
+            name = "GitHubPackages-jhwbus"
+            url = uri("https://maven.pkg.github.com/org-arl/jhwbus")
+            credentials {
+                username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
+                password = project.findProperty("gpr.token") ?: System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ['-Xlint:unchecked']
+}
+
+tasks.register('compileC', Exec) {
+    description = 'Compile C code'
+    outputs.file project.layout.buildDirectory.file('libjhwbus.so')
+    executable 'gcc'
+    args "-std=c99", "-O2", "-Wall", "-Wextra", "-Werror",
+        "-Wno-unused-parameter", "-D_XOPEN_SOURCE=600", "-fPIC",
+        '-I', '/usr/local/include',
+        '-I', JNI_INCLUDE_DIR
+    args '-I', JNI_INCLUDE_DIR + '/linux'
+    args '-shared'
+    inputs.files fileTree('src/main/c') { include '**/*.c' }
+    args '-o', outputs.files.singleFile
+    args inputs.files
+    args '-li2c'
+
+}
+
+tasks.register('createJhwbusResourceDir', Sync) {
+    description = 'Create jhwbus resource directory'
+    from tasks.named('compileC')
+    into project.layout.buildDirectory.dir('jhwbus')
+}
+
+sourceSets.main.resources.srcDirs tasks.named('createJhwbusResourceDir')
+
+jar {
+    enabled = OS_NAME == 'linux'
+}
+
+String image =  project.properties['dockerImage'] ?: "ghcr.io/org-arl/jhwbus:latest"
+String dockerContext = project.properties['dockerContext'] ?: 'colima'
+tasks.register('buildImage'){
+    description = 'Builds a docker image'
+    doLast {
+        exec {
+            commandLine 'docker', 'build', '-t', image, '.'
+        }
+    }
+}
+
+tasks.register('pushImage'){
+    description = 'Pushes the docker image to GitHub Packages'
+    dependsOn 'buildImage'
+    doLast {
+        exec {
+            commandLine 'docker', 'push', image
+        }
+    }
+}
+
+project.ext.container = null
+tasks.register('startContainer') {
+    description = 'Starts a container'
+    doLast {
+        if (project.ext.container instanceof String) return
+
+        // start a container using docker cli and exec
+        println "Starting a new container ($image)... "
+        project.ext.container = execWithOutput('docker','--context', dockerContext , 'run', '-d', '-v', "$rootDir:/home/jhwbus", image, 'sleep', 'infinity')
+    }
+}
+
+tasks.register('stopContainer') {
+    description = 'Stops the container'
+    doLast {
+        if (!(project.ext.container instanceof String)) return
+        // stop the container using docker cli and exec
+        execWithOutput('docker', '--context', dockerContext , 'stop', project.ext.container as String)
+        println "Stopped the container"
+        project.ext.container = null
+    }
+}
+
+tasks.register('containerJar') {
+    description = 'Builds jhwbus in a container'
+    dependsOn tasks.startContainer
+    finalizedBy tasks.stopContainer
+    doLast {
+        def containerId = project.ext.container
+        if (!containerId || !(containerId instanceof String)) {
+            throw new GradleException("No known container!")
+        }
+        // check if the container is running using docker cli
+        def running = execWithOutput('docker', '--context', dockerContext, 'inspect', '-f', '{{.State.Running}}', containerId as String)
+        if (running != 'true') {
+            throw new GradleException("Container is not running!")
+        }
+        // exec the build command in the container
+        println "Running build in a container : ${containerId.take(12)}"
+        def res = exec {
+            commandLine 'docker', '--context', dockerContext , 'exec', containerId, '/bin/bash', '-c', "./gradlew -Dorg.gradle.welcome=never jar"
+            ignoreExitValue true
+        }
+        if (res.exitValue != 0) {
+            throw new GradleException("Container build failed!")
+        }
+    }
+    outputs.file file("$buildDir/libs/jhwbus-${version}.jar")
+}
+
 test {
     useJUnitPlatform()
     testLogging.showStandardStreams = true
@@ -63,4 +176,21 @@ test {
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"
     }
+}
+
+//// Internal helpers
+
+def execWithOutput(String... command) {
+    def stdout = new ByteArrayOutputStream()
+    def stderr = new ByteArrayOutputStream()
+    def res = exec {
+        commandLine command
+        standardOutput = stdout
+        errorOutput = stderr
+        ignoreExitValue true
+    }
+    if (res.exitValue != 0) {
+        throw new GradleException("Failed to execute command : ${command.join(' ')} \n ${stderr.toString()}")
+    }
+    return stdout.toString().trim()
 }

--- a/src/main/c/i2c.c
+++ b/src/main/c/i2c.c
@@ -48,87 +48,52 @@ void log_info(const char *format, ...) {
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2COpen(JNIEnv* env, jobject obj, jstring dev, jint addr){
-    int fd = 42;
     const char* devName = (*env)->GetStringUTFChars(env, dev, NULL) ;
     log_open("jhwbus-i2c.txt");
     log_info("Opening I2C device %s", devName);
-#ifdef __linux__
-    fd = open(devName, O_RDWR);
-#endif
-    return fd;
+    return open(devName, O_RDWR);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CSetAddr(JNIEnv* env, jobject obj, jint fd, jbyte addr){
     log_info("Setting I2C addr 0x%02X", addr);
-    int rv = 0;
-    #ifdef __linux__
-        rv = ioctl(fd, I2C_SLAVE, addr);
-    #endif
-    return rv;
+    return ioctl(fd, I2C_SLAVE, addr);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CReadByte(JNIEnv* env, jobject obj, jint fd){
-    int rv = 0;
     log_info("Reading a byte");
-    #ifdef __linux__
-        rv = i2c_smbus_read_byte(fd);
-    #endif
-    return rv;
+    return i2c_smbus_read_byte(fd);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CWriteByte(JNIEnv* env, jobject obj, jint fd, jbyte data){
-    int rv = 0;
     log_info("Writing a byte 0x%02X", data);
-    #ifdef __linux__
-        rv = i2c_smbus_write_byte(fd, data);
-    #endif
-    return rv;
+    return i2c_smbus_write_byte(fd, data);;
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CWriteByteData(JNIEnv* env, jobject obj, jint fd, jbyte cmd, jbyte data){
-    int rv = 0;
     log_info("Writing a command 0x%02X and byte data 0x%02X", cmd, data);
-    #ifdef __linux__
-        rv = i2c_smbus_write_byte_data(fd, cmd, data);
-    #endif
-    return rv;
+    return i2c_smbus_write_byte_data(fd, cmd, data);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CWriteWordData(JNIEnv* env, jobject obj, jint fd, jbyte cmd, jint data){
-    int rv = 0;
     log_info("Writing a command 0x%02X and word data 0x%04X", cmd, data);
-    #ifdef __linux__
-        rv = i2c_smbus_write_word_data(fd, cmd, data);
-    #endif
-    return rv;
+    return i2c_smbus_write_word_data(fd, cmd, data);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CReadByteData(JNIEnv* env, jobject obj, jint fd, jbyte cmd){
-    int rv = 0;
     log_info("Reading a byte data with the command 0x%02X", cmd);
-    #ifdef __linux__
-        rv = i2c_smbus_read_byte_data(fd, cmd);
-    #endif
-    return rv;
+    return i2c_smbus_read_byte_data(fd, cmd);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CReadWordData(JNIEnv* env, jobject obj, jint fd, jbyte cmd){
-    int rv = 0;
     log_info("Reading a word data with the command 0x%02X", cmd);
-    #ifdef __linux__
-        rv = i2c_smbus_read_word_data(fd, cmd);
-    #endif
-    return rv;
+    return i2c_smbus_read_word_data(fd, cmd);
 }
 
 int Java_org_arl_jhwbus_I2CDevice_I2CReadBlockData(JNIEnv* env, jobject obj, jint fd, jbyte cmd, jbyteArray arr){
     jsize len = (*env)->GetArrayLength(env, arr);
     jbyte *rbuf = (*env)->GetByteArrayElements(env, arr, 0);
-    int rv = 0;
     log_info("Reading up to %d bytes of data with the command 0x%02X", len, cmd);
-    #ifdef __linux__
-        rv = i2c_smbus_read_i2c_block_data(fd, cmd, len, (unsigned char *)rbuf);
-    #endif
+    int rv = i2c_smbus_read_i2c_block_data(fd, cmd, len, (unsigned char *)rbuf);
     (*env)->ReleaseByteArrayElements(env, arr, rbuf, 0);
     return rv;
 }
@@ -137,10 +102,7 @@ int Java_org_arl_jhwbus_I2CDevice_I2CRead(JNIEnv* env, jobject obj, jint fd, jby
     jsize len = (*env)->GetArrayLength(env, arr);
     jbyte *rbuf = (*env)->GetByteArrayElements(env, arr, 0);
     log_info("Reading %d bytes of data", len);
-    int rv = 0;
-    #ifdef __linux__
-        rv = read(fd, rbuf, len);
-    #endif
+    int rv = read(fd, rbuf, len);
     (*env)->ReleaseByteArrayElements(env, arr, rbuf, 0);
     return rv;
 }
@@ -149,10 +111,7 @@ int Java_org_arl_jhwbus_I2CDevice_I2CWrite(JNIEnv* env, jobject obj, jint fd, jb
     jsize len = (*env)->GetArrayLength(env, arr);
     jbyte *wbuf = (*env)->GetByteArrayElements(env, arr, 0);
     log_info("Writing %d bytes of data", len);
-    int rv = 0;
-    #ifdef __linux__
-        rv = write(fd, wbuf, len);
-    #endif
+    int rv = write(fd, wbuf, len);
     (*env)->ReleaseByteArrayElements(env, arr, wbuf, 0);
     return rv;
 }
@@ -163,12 +122,9 @@ int Java_org_arl_jhwbus_I2CDevice_I2CWriteRead(JNIEnv* env, jobject obj, jint fd
     jsize rlen = (*env)->GetArrayLength(env, rarr);
     jbyte *rbuf = (*env)->GetByteArrayElements(env, rarr, 0);
     log_info("Writing %d bytes of data, reading %d bytes of data", wlen, rlen);
-    int rv = 0;
-    #ifdef __linux__
-        rv = write(fd, wbuf, wlen);
-        if (rv == wlen) rv = read(fd, rbuf, rlen);
-        else rv = -1;
-    #endif
+    int rv = write(fd, wbuf, wlen);
+    if (rv == wlen) rv = read(fd, rbuf, rlen);
+    else rv = -1;
     (*env)->ReleaseByteArrayElements(env, warr, wbuf, 0);
     (*env)->ReleaseByteArrayElements(env, rarr, rbuf, 0);
     return rv;
@@ -176,7 +132,5 @@ int Java_org_arl_jhwbus_I2CDevice_I2CWriteRead(JNIEnv* env, jobject obj, jint fd
 
 void Java_org_arl_jhwbus_I2CDevice_I2CClose(JNIEnv* env, jobject obj, jint fd){
     log_info("Closing the I2C Interface");
-    #ifdef __linux__
-        close(fd);
-    #endif
+    close(fd);
 }

--- a/src/main/java/org/arl/jhwbus/I2CDevice.java
+++ b/src/main/java/org/arl/jhwbus/I2CDevice.java
@@ -253,13 +253,11 @@ public final class I2CDevice {
   // JNI interface
 
   static {
-    String libSuffix = "";
     String os = System.getProperty("os.name").toLowerCase();
-    if (os.contains("linux")) libSuffix += ".so";
-    else if (os.contains("mac")) libSuffix += ".dylib";
-
-    String libName = "libjhwbus" + libSuffix;
-
+    if (!os.contains("linux")){
+      throw new RuntimeException("This library is only supported on Linux");
+    }
+    String libName = "libjhwbus.so";
     AccessController.doPrivileged(new PrivilegedAction<Void>() {
       public Void run() {
         try {


### PR DESCRIPTION
Since `jhwbus` only supports Linux/ARM, I cleaned up some code to allow us to compile and publish it instead of using it as a source dependency.

- Removed debug code (and tools to compile it) created a `libjhwbus.dylib`, since it didn't actually work.
- Split the build so that on Linux, the build happens locally, while on other OS, a Linux container is used.
- Add Gradle config for publishing the assembled jar so that it can be consumed directly by other projects.
- Add a check in the `static` JNI loader to throw an exception if not on Linux.